### PR TITLE
Add share modal with export options

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -201,3 +201,43 @@ table th {
   list-style-type: disc;
   margin-left: 20px;
 }
+
+/* Modal used for share options */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.modal-content {
+  background-color: #fff;
+  margin: 10% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%;
+  max-width: 500px;
+  border-radius: 4px;
+}
+
+.modal-content .close {
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.share-option {
+  margin-top: 15px;
+}
+
+.share-option .note {
+  font-size: 0.8em;
+  color: #666;
+  margin-top: 5px;
+}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,22 @@
     <div class="share-container">
       <button type="button" id="shareBtn" style="display:none;">Share</button>
     </div>
+    <div id="shareModal" class="modal">
+      <div class="modal-content">
+        <span class="close" id="closeShareModal">&times;</span>
+        <h2>Share</h2>
+        <div class="share-option">
+          <button type="button" id="copyUrlBtn">Copy share URL</button>
+          <p class="note">URL is often too long to share directly.</p>
+        </div>
+        <div class="share-option">
+          <button type="button" id="downloadHtmlBtn">Download HTML file</button>
+        </div>
+        <div class="share-option">
+          <button type="button" id="downloadPdfBtn">Download PDF file</button>
+        </div>
+      </div>
+    </div>
     <p>
       Upload your <code>Streaming_History_Audio_*.json</code> files—or the
       entire <code>my_spotify_data.zip</code> export—from your Spotify privacy

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <h2>Share</h2>
         <div class="share-option">
           <button type="button" id="copyUrlBtn">Copy share URL</button>
-          <p class="note">URL is often too long to share directly.</p>
+          <p class="note">Sometimes URL is too long to share directly.</p>
         </div>
         <div class="share-option">
           <button type="button" id="downloadHtmlBtn">Download HTML file</button>


### PR DESCRIPTION
## Summary
- enable share modal with copy URL, HTML and PDF download options
- support modal styling

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6886233e5be0832c82485727ffa7f4ff